### PR TITLE
Remove print() and new() from Storer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod store;
+pub mod store;
 
 use crypto_hash::{digest, Algorithm};
 

--- a/src/store/mem_store/mod.rs
+++ b/src/store/mem_store/mod.rs
@@ -2,14 +2,38 @@ use std::convert::TryFrom;
 
 use crate::store::Storer;
 
+#[derive(Debug)]
 pub struct MemStore {
     data: Vec<Vec<Vec<u8>>>,
 }
 
-impl Storer for MemStore {
-    fn new() -> MemStore {
+impl MemStore {
+    pub fn new() -> Self {
         MemStore { data: vec![vec![]] }
     }
+
+    pub fn print(&self) {
+        let mut tab: String;
+        let mut i: isize = isize::try_from(self.data.len()).unwrap() - 1;
+        while i >= 0 {
+            print!("{}", String::from("  ").repeat((1 << i) - 1));
+            tab = String::from("  ").repeat((1 << (i + 1)) - 1);
+            for layer in self.data[i as usize].iter() {
+                print!("{:?}{}", layer[0], tab);
+            }
+            println!();
+            i -= 1;
+        }
+    }
+}
+
+impl Default for MemStore {
+    fn default() -> Self {
+        MemStore::new()
+    }
+}
+
+impl Storer for MemStore {
     /*
         Note: width of the tree tells us how many values are in the ledger
         e.g.
@@ -50,19 +74,6 @@ impl Storer for MemStore {
             return None;
         }
         Some(self.data[layer as usize][index as usize].to_vec())
-    }
-    fn print(&self) {
-        let mut tab: String;
-        let mut i: isize = isize::try_from(self.data.len()).unwrap() - 1;
-        while i >= 0 {
-            print!("{}", String::from("  ").repeat((1 << i) - 1));
-            tab = String::from("  ").repeat((1 << (i + 1)) - 1);
-            for layer in self.data[i as usize].iter() {
-                print!("{:?}{}", layer[0], tab);
-            }
-            println!();
-            i -= 1;
-        }
     }
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,9 +1,7 @@
 pub mod mem_store;
 
 pub trait Storer {
-    fn new() -> Self;
     fn width(&self) -> isize;
     fn set(&mut self, layer: isize, index: isize, value: &[u8]);
     fn get(&self, layer: isize, index: isize) -> Option<Vec<u8>>;
-    fn print(&self);
 }


### PR DESCRIPTION
`print()` and `new()` probably are not part of the `Storer` trait and so can be implemented as normal member functions.